### PR TITLE
Corrected variable type in iOS snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Data Usage gets Mobile/Wifi data usage values from mobile devices, on android it
  Request for Total data usage on iOS devices
 
    ```dart
-     Future<IOSDataUsageModel> dataUsage = await DataUsage.dataUsageIOS();
+     IOSDataUsageModel dataUsage = await DataUsage.dataUsageIOS();
    ```
 
  This would return:


### PR DESCRIPTION
Removed the `Future` in `Future<IOSDataUsageModel> dataUsage = await DataUsage.dataUsageIOS();` (because of the `await` keyword).