### PR TITLE
fix wrong permission request: 

### DIFF
--- a/android/src/main/kotlin/com/chizi/data_usage/DataUsagePlugin.kt
+++ b/android/src/main/kotlin/com/chizi/data_usage/DataUsagePlugin.kt
@@ -105,7 +105,7 @@ class DataUsagePlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
 
     private fun requestPermission() {
         ActivityCompat.requestPermissions(activity!!,
-                arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE), myPermissionCode)
+                arrayOf(Manifest.permission.READ_PHONE_STATE), myPermissionCode)
 
     }
 


### PR DESCRIPTION
from external storage permission to phone state permission
this permission was not added to the plugin manifest and w don't need external storage permission to accesss usage data